### PR TITLE
feat: Add Stückzahl field for product quantity

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,12 @@
             <div class="input-group" id="selected-food" style="display: none;">
                 <label>Ausgewähltes Produkt:</label>
                 <div id="food-info"></div>
-                <label for="quantity">Menge (g):</label>
-                <div id="quantity-controls" style="display: flex; align-items: center; gap: 5px;">
-                    <input type="number" id="quantity" value="100" min="1" style="flex-grow: 1;">
+                <label for="quantity">Menge pro Stück (g):</label>
+                <div id="quantity-controls">
+                    <input type="number" id="quantity" value="100" min="1">
+                    <input type="number" id="stueckzahl" min="1" placeholder="Stk.">
                 </div>
-                <button onclick="addFood()" style="margin-top: 10px;">Hinzufügen</button>
+                <button onclick="addFood()">Hinzufügen</button>
             </div>
 
             <!-- Kalorien-Diagramm -->
@@ -261,14 +262,17 @@
             } else {
                 document.getElementById('quantity').value = 100;
             }
+            document.getElementById('stueckzahl').value = 1;
             foodInfo.innerHTML = infoText;
             document.getElementById('selected-food').style.display = 'block';
         }
 
         function addFood() {
             if (!currentFood) return;
-            const quantity = parseFloat(document.getElementById('quantity').value) || 100;
-            const calories = Math.round((currentFood.calories * quantity) / 100);
+            const grams_per_piece = parseFloat(document.getElementById('quantity').value) || (currentFood.servingSize || 100);
+            const stueckzahl = Math.max(1, parseFloat(document.getElementById('stueckzahl').value) || 1);
+            const totalQuantity = grams_per_piece * stueckzahl;
+            const calories = Math.round((currentFood.calories * totalQuantity) / 100);
 
             const today = new Date().toISOString().split('T')[0];
             const dailyFoodLog = JSON.parse(localStorage.getItem('dailyFoodLog') || '{}');
@@ -278,9 +282,11 @@
 
             // Add a unique ID to the food item using timestamp
             dailyFoodLog[today].push({
-                id: Date.now(),
+                id: Date.now(), // Ensure this ID remains unique
                 name: currentFood.name,
-                quantity: quantity,
+                grams_per_piece: grams_per_piece, // Store grams per piece
+                stueckzahl: stueckzahl,           // Store stueckzahl
+                quantity: totalQuantity,          // This 'quantity' is now total grams
                 calories: calories
             });
 
@@ -291,6 +297,7 @@
             document.getElementById('food-search').value = '';
             document.getElementById('selected-food').style.display = 'none';
             document.getElementById('quantity').value = 100;
+            document.getElementById('stueckzahl').value = 1;
             currentFood = null;
 
             // Reload the food list and update charts/totals
@@ -317,8 +324,11 @@
                 dailyFoodLog[today].forEach(food => {
                     const listItem = document.createElement('li');
                     listItem.className = 'food-item';
+                    const displayQuantity = food.stueckzahl && food.grams_per_piece ?
+                                            `${food.stueckzahl} Stk. à ${food.grams_per_piece}g` :
+                                            `${food.quantity}g`;
                     listItem.innerHTML = `
-                        <span>${food.name} (${food.quantity}g)</span>
+                        <span>${food.name} (${displayQuantity})</span>
                         <span>${food.calories} kcal</span>
                         <button class="action-btn edit-btn" onclick="editFood(${food.id})">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -352,19 +362,11 @@
 
         if (itemIndex !== -1) {
             const foodToEdit = dailyFoodLog[today][itemIndex];
-            const originalQuantity = foodToEdit.quantity; // Ursprüngliche Menge sichern
+            // const originalQuantity = foodToEdit.quantity; // Ursprüngliche Menge sichern - replaced by new logic
 
             // Display modal
             const modal = document.createElement('div');
-            modal.style.position = 'fixed';
-            modal.style.top = '50%';
-            modal.style.left = '50%';
-            modal.style.transform = 'translate(-50%, -50%)';
-            modal.style.padding = '20px';
-            modal.style.border = '1px solid #ccc';
-            modal.style.borderRadius = '8px';
-            modal.style.backgroundColor = '#fff';
-            modal.style.zIndex = '1000';
+            modal.classList.add('modal'); // Add a class for styling
 
             const label = document.createElement('label');
             label.textContent = 'Neue Portionsmenge (g): ';
@@ -376,13 +378,26 @@
 
             const submitBtn = document.createElement('button');
             submitBtn.textContent = 'Save Changes';
-            submitBtn.style.marginTop = '10px'; // Apply margin-left directly
+            submitBtn.classList.add('modal-button'); // Add a class for styling
             submitBtn.onclick = () => {
                 const newQuantity = parseFloat(input.value);
-                foodToEdit.quantity = newQuantity; // Aktualisieren
+                
+                // Find the base product info to get calories per 100g
+                const products = JSON.parse(localStorage.getItem('customProducts') || '[]');
+                const baseProduct = products.find(p => p.name === foodToEdit.name); // Assuming name is unique
 
-                // Kalorienberechnung mit ursprünglicher Menge als Basis
-                foodToEdit.calories = Math.round(foodToEdit.calories * (newQuantity / originalQuantity));
+                if (baseProduct) {
+                    foodToEdit.calories = Math.round((baseProduct.calories * newQuantity) / 100);
+                } else {
+                    // Fallback: Estimate from original calorie/quantity ratio if base product not found
+                    const originalCaloriesPerGram = foodToEdit.calories / foodToEdit.quantity;
+                    foodToEdit.calories = Math.round(originalCaloriesPerGram * newQuantity);
+                }
+                foodToEdit.quantity = newQuantity; // Update to new total quantity
+
+                // Remove stueckzahl and grams_per_piece as the edit is now for total quantity
+                delete foodToEdit.grams_per_piece;
+                delete foodToEdit.stueckzahl;
 
                 // Save updated log
                 localStorage.setItem('dailyFoodLog', JSON.stringify(dailyFoodLog));

--- a/styles.css
+++ b/styles.css
@@ -673,3 +673,43 @@ tr:nth-child(even) {
         height: 24px;
     }
 }
+
+/* Styles for the quantity and stueckzahl input group */
+#quantity-controls {
+    display: flex;
+    align-items: center; /* Vertically align items in the center */
+    gap: 10px; /* Space between the input fields */
+    margin-top: 5px; /* Add some space below the label */
+}
+
+#quantity-controls input#quantity {
+    flex-grow: 2; /* Allow quantity to take more space */
+    /* width: 60%; */ /* Alternatively, use flex-basis or width if flex-grow is not enough */
+}
+
+#quantity-controls input#stueckzahl {
+    flex-grow: 1; /* Allow stueckzahl to take less space */
+    /* width: 35%; */ /* Alternatively, use flex-basis or width */
+}
+
+/* Ensure inputs don't get too small on narrow screens if they have placeholders */
+#quantity-controls input#quantity,
+#quantity-controls input#stueckzahl {
+    min-width: 60px; /* Adjust as needed, placeholder "Stk." needs some space */
+}
+
+/* Optional: Media query for very small screens if vertical stacking is desired */
+/*
+@media (max-width: 360px) {
+    #quantity-controls {
+        flex-direction: column;
+        align-items: stretch; /* Stretch items to fill width */
+    }
+
+    #quantity-controls input#quantity,
+    #quantity-controls input#stueckzahl {
+        width: 100%; /* Make inputs take full width when stacked */
+        min-width: auto; /* Reset min-width */
+    }
+}
+*/


### PR DESCRIPTION
This commit introduces a 'Stückzahl' (number of pieces) field in the product selection area, allowing you to specify quantity in terms of pieces and grams per piece.

Changes include:
- Modified `index.html`:
    - Added an input field for 'Stückzahl' alongside the 'Menge (g)' field.
    - Relabeled 'Menge (g)' to 'Menge pro Stück (g)'.
- Updated JavaScript in `index.html`:
    - `selectFood()`: Defaults Stückzahl to 1 on product selection.
    - `addFood()`:
        - Reads Stückzahl and Menge pro Stück.
        - Calculates total quantity and calories based on these inputs. - Stores Stückzahl, Menge pro Stück, and total quantity in the daily food log.
    - `loadDailyFoodLog()`: Displays items with Stückzahl and Menge pro Stück in the format "Name (X Stk. à Yg)".
    - `editFood()`: When editing an item with Stückzahl, it's converted to a simple gram-based entry. Calorie recalculation now uses base product calorie data.
- Updated `styles.css`:
    - Added styles for the new input field layout, ensuring proper alignment and responsiveness.
    - Removed associated inline styles from `index.html`.